### PR TITLE
fix wrong chat id json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ As described in the Telegram Bot API, this is the manual procedure needed in ord
 2. Create the destination chat and get the `chatId`
 	* Open a new chat with your new Bot and post a message on the chat
 	* Open a browser and invoke `https://api.telegram.org/bot<botToken>/getUpdates` (where `<botToken>` is the `botToken` previously obtained)
-	* Look at the JSON result and write down the value of `result[0].message.from.id`. That is the chatId.
+	* Look at the JSON result and write down the value of `result[0].message.chat.id`. That is the chatId.


### PR DESCRIPTION
`result[0].message.from.id` points to the test message author id, i.e. to your id. Should be `result[0].message.chat.id`. Btw, I would add that a chat id can be negative since it's can be confusing.